### PR TITLE
FEAT: jwt-decoder 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "aws-sdk": "^2.1282.0",
         "axios": "^1.2.1",
         "dotenv": "^16.0.3",
+        "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.5",
@@ -22972,6 +22973,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/keyv": {
       "version": "3.1.0",
@@ -50079,6 +50085,11 @@
       "resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
       "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
       "dev": true
+    },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "keyv": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "aws-sdk": "^2.1282.0",
     "axios": "^1.2.1",
     "dotenv": "^16.0.3",
+    "jwt-decode": "^3.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",

--- a/src/utils/jwtHandler.js
+++ b/src/utils/jwtHandler.js
@@ -1,0 +1,5 @@
+import jwt_decode from 'jwt-decode';
+
+export const getUserIdFromAccessToken = (token) => {
+  return jwt_decode(token).userId;
+};


### PR DESCRIPTION

**왜함**

authorization 헤더의 accessToken을 넘겨 내 정보를 조회 해오는 api 따로 없이

회원 아이디로 회원정보 조회만 할 수 있게 구성되어있다.

로그인 성공 시 얻은 accessToken의 payload안에 있는 userId를 활용해 내 정보를 조회해와 global state로 관리하여야 한다.